### PR TITLE
build fix: include common.h after SDL_mixer.h to make SDL mixer backward...

### DIFF
--- a/modules/marmalade.c
+++ b/modules/marmalade.c
@@ -29,11 +29,11 @@
  **/
 
 #include <string.h>
-#include "common.h"
 #include <pthread.h>
 #include <signal.h>
-#include "SDL/SDL.h"
-#include "SDL/SDL_mixer.h"
+#include <SDL/SDL.h>
+#include <SDL/SDL_mixer.h>
+#include "common.h"
 
 #include "../platform.h"
 


### PR DESCRIPTION
...s

compatibility effective.
