### PR TITLE
marmalade_CallIntMethodV: return if method is NULL

### DIFF
--- a/modules/marmalade.c
+++ b/modules/marmalade.c
@@ -469,6 +469,11 @@ marmalade_CallIntMethodV(JNIEnv *env, jobject p1, jmethodID p2, va_list p3)
 {
     jmethodID method = p2;
 
+    if(NULL == p2)
+    {
+        return -1;
+    }
+
     MODULE_DEBUG_PRINTF("marmalade_CallIntMethodV(%s)\n",p2->name);
 
     if(method_is(getOrientation))


### PR DESCRIPTION
marmalade_CallIntMethodV: return if method is NULL, fixes NULL pointer dereference in doodlejump
