### PR TITLE
libhybris and apkenv conflict

### DIFF
--- a/apkenv.h
+++ b/apkenv.h
@@ -220,8 +220,8 @@ struct GlobalState {
 #endif
 
 /* Forward-declarations for the Bionic linker */
-void *android_dlopen(const char *filename, int flag);
-void *android_dlsym(void *handle, const char *symbol);
+void *apkenv_android_dlopen(const char *filename, int flag);
+void *apkenv_android_dlsym(void *handle, const char *symbol);
 
 /* Module support */
 typedef int (*apkenv_module_init_t)(int version, struct SupportModule *module);

--- a/compat/egl_wrappers.c
+++ b/compat/egl_wrappers.c
@@ -11,7 +11,7 @@ void *
 my_eglGetProcAddress(const char *procname)
 {
     WRAPPERS_DEBUG_PRINTF("eglGetProcAddress(%s)\n", procname);
-    void *sym = get_hooked_symbol(procname, 1);
+    void *sym = apkenv_get_hooked_symbol(procname, 1);
     if (sym == NULL)
         printf("eglGetProcAddress: unimplemented: %s\n", procname);
     return sym;

--- a/compat/hooks.c
+++ b/compat/hooks.c
@@ -110,7 +110,7 @@ hook_cmp(const void *p1, const void *p2)
 
 #define HOOK_SIZE (sizeof(struct _hook))
 
-void *get_hooked_symbol(const char *sym, int die_if_pthread)
+void *apkenv_get_hooked_symbol(const char *sym, int die_if_pthread)
 {
     struct _hook target;
     target.name = sym;
@@ -130,7 +130,7 @@ void *get_hooked_symbol(const char *sym, int die_if_pthread)
     return NULL;
 }
 
-void *get_hooked_symbol_dlfcn(void *handle, const char *sym)
+void *apkenv_get_hooked_symbol_dlfcn(void *handle, const char *sym)
 {
     struct _hook *result;
     struct _hook target;
@@ -158,7 +158,7 @@ void *get_hooked_symbol_dlfcn(void *handle, const char *sym)
 #endif
     }
 
-    return get_hooked_symbol(sym, 1);
+    return apkenv_get_hooked_symbol(sym, 1);
 }
 
 int register_hooks(const struct _hook *new_hooks, size_t count)
@@ -231,7 +231,7 @@ void hooks_init(void)
             break;
     hooks_count = i;
 
-    /* Sort hooks so we can use binary search in get_hooked_symbol() */
+    /* Sort hooks so we can use binary search in apkenv_get_hooked_symbol() */
     qsort(&(hooks[0]), hooks_count, HOOK_SIZE, hook_cmp);
 #ifdef APKENV_GLES
     qsort(hooks_gles1, HOOKS_GLES1_COUNT, HOOK_SIZE, hook_cmp);

--- a/compat/hooks.h
+++ b/compat/hooks.h
@@ -38,8 +38,8 @@ struct _hook {
   void *func;
 };
 
-void *get_hooked_symbol(const char *sym, int die_if_pthread);
-void *get_hooked_symbol_dlfcn(void *handle, const char *sym);
+void *apkenv_get_hooked_symbol(const char *sym, int die_if_pthread);
+void *apkenv_get_hooked_symbol_dlfcn(void *handle, const char *sym);
 void *get_builtin_lib_handle(const char *libname);
 int is_builtin_lib_handle(void *handle);
 int register_hooks(const struct _hook *hooks, size_t count);

--- a/jni/shlib.c
+++ b/jni/shlib.c
@@ -111,7 +111,7 @@ jni_shlib_resolve(struct GlobalState *global, const char *method)
             if (strstr(*method_table, method) != NULL) {
                 JNISHLIB_DEBUG_PRINTF("[shlib] Found symbol: %s\n",
                         *method_table);
-                return android_dlsym(lib->lib, *method_table);
+                return apkenv_android_dlsym(lib->lib, *method_table);
             }
             method_table++;
         }
@@ -135,7 +135,7 @@ jni_shlib_lib_resolve(struct GlobalState *global, const char* libname, const cha
                 if (strstr(*method_table, method) != NULL) {
                     JNISHLIB_DEBUG_PRINTF("[shlib] Found symbol: %s in %s\n",
                             *method_table,lib->name);
-                    return android_dlsym(lib->lib, *method_table);
+                    return apkenv_android_dlsym(lib->lib, *method_table);
                 }
                 method_table++;
             }

--- a/linker/linker.h
+++ b/linker/linker.h
@@ -41,8 +41,7 @@
 #define PAGE_SIZE 4096
 #define PAGE_MASK 4095
 
-void debugger_init();
-const char *addr_to_name(unsigned addr);
+void apkenv_debugger_init();
 
 /* magic shared structures that GDB knows about */
 
@@ -207,23 +206,23 @@ extern soinfo libdl_info;
 #define DT_PREINIT_ARRAYSZ 33
 #endif
 
-soinfo *find_library(const char *name);
-unsigned unload_library(soinfo *si);
-Elf32_Sym *lookup_in_library(soinfo *si, const char *name);
-Elf32_Sym *lookup(const char *name, soinfo **found, soinfo *start);
-soinfo *find_containing_library(const void *addr);
-Elf32_Sym *find_containing_symbol(const void *addr, soinfo *si);
-const char *linker_get_error(void);
-void call_constructors_recursive(soinfo *si);
+soinfo *apkenv_find_library(const char *name);
+unsigned apkenv_unload_library(soinfo *si);
+Elf32_Sym *apkenv_lookup_in_library(soinfo *si, const char *name);
+Elf32_Sym *apkenv_lookup(const char *name, soinfo **found, soinfo *start);
+soinfo *apkenv_find_containing_library(const void *addr);
+Elf32_Sym *apkenv_find_containing_symbol(const void *addr, soinfo *si);
+const char *apkenv_linker_get_error(void);
+void apkenv_call_constructors_recursive(soinfo *si);
 
 #ifdef ANDROID_ARM_LINKER
 typedef long unsigned int *_Unwind_Ptr;
-_Unwind_Ptr dl_unwind_find_exidx(_Unwind_Ptr pc, int *pcount);
+_Unwind_Ptr apkenv_dl_unwind_find_exidx(_Unwind_Ptr pc, int *pcount);
 #elif defined(ANDROID_X86_LINKER)
-int dl_iterate_phdr(int (*cb)(struct dl_phdr_info *, size_t, void *), void *);
+int apkenv_dl_iterate_phdr(int (*cb)(struct dl_phdr_info *, size_t, void *), void *);
 #endif
 
-void notify_gdb_of_libraries(void);
-int add_sopath(const char *path);
+void apkenv_notify_gdb_of_libraries(void);
+int apkenv_add_sopath(const char *path);
 
 #endif

--- a/linker/linker_environ.c
+++ b/linker/linker_environ.c
@@ -36,7 +36,7 @@ static char** _envp;
  *  - It contains at least one equal sign that is not the first character
  */
 static int
-_is_valid_definition(const char*  str)
+apkenv__is_valid_definition(const char*  str)
 {
     int   pos = 0;
     int   first_equal_pos = -1;
@@ -68,7 +68,7 @@ _is_valid_definition(const char*  str)
 }
 
 unsigned*
-linker_env_init(unsigned* vecs)
+apkenv_linker_env_init(unsigned* vecs)
 {
     /* Store environment pointer - can't be NULL */
     _envp = (char**) vecs;
@@ -86,7 +86,7 @@ linker_env_init(unsigned* vecs)
         char** readp  = _envp;
         char** writep = _envp;
         for ( ; readp[0] != NULL; readp++ ) {
-            if (!_is_valid_definition(readp[0]))
+            if (!apkenv__is_valid_definition(readp[0]))
                 continue;
             writep[0] = readp[0];
             writep++;
@@ -103,7 +103,7 @@ linker_env_init(unsigned* vecs)
  * first character after the equal sign. Otherwise return NULL.
  */
 static char*
-env_match(char* envstr, const char* name)
+apkenv_env_match(char* envstr, const char* name)
 {
     size_t  cnt = 0;
 
@@ -119,7 +119,7 @@ env_match(char* envstr, const char* name)
 #define MAX_ENV_LEN  (16*4096)
 
 const char*
-linker_env_get(const char* name)
+apkenv_linker_env_get(const char* name)
 {
     char** readp = _envp;
 
@@ -127,7 +127,7 @@ linker_env_get(const char* name)
         return NULL;
 
     for ( ; readp[0] != NULL; readp++ ) {
-        char* val = env_match(readp[0], name);
+        char* val = apkenv_env_match(readp[0], name);
         if (val != NULL) {
             /* Return NULL for empty strings, or if it is too large */
             if (val[0] == '\0')
@@ -140,7 +140,7 @@ linker_env_get(const char* name)
 
 
 void
-linker_env_unset(const char* name)
+apkenv_linker_env_unset(const char* name)
 {
     char**  readp = _envp;
     char**  writep = readp;
@@ -149,7 +149,7 @@ linker_env_unset(const char* name)
         return;
 
     for ( ; readp[0] != NULL; readp++ ) {
-        if (env_match(readp[0], name))
+        if (apkenv_env_match(readp[0], name))
             continue;
         writep[0] = readp[0];
         writep++;
@@ -163,7 +163,7 @@ linker_env_unset(const char* name)
 /* Remove unsafe environment variables. This should be used when
  * running setuid programs. */
 void
-linker_env_secure(void)
+apkenv_linker_env_secure(void)
 {
     /* The same list than GLibc at this point */
     static const char* const unsec_vars[] = {
@@ -198,7 +198,7 @@ linker_env_secure(void)
     const char* const* endp = cp + sizeof(unsec_vars)/sizeof(unsec_vars[0]);
 
     while (cp < endp) {
-        linker_env_unset(*cp);
+        apkenv_linker_env_unset(*cp);
         cp++;
     }
 }

--- a/linker/linker_environ.h
+++ b/linker/linker_environ.h
@@ -32,23 +32,23 @@
  * to the environment block in the ELF data block. The function returns
  * the start of the aux vectors after the env block.
  */
-extern unsigned*   linker_env_init(unsigned* vecs);
+extern unsigned*   apkenv_linker_env_init(unsigned* vecs);
 
 /* Unset a given environment variable. In case the variable is defined
  * multiple times, unset all instances. This modifies the environment
  * block, so any pointer returned by linker_env_get() after this call
  * might become invalid */
-extern void        linker_env_unset(const char* name);
+extern void        apkenv_linker_env_unset(const char* name);
 
 
 /* Returns the value of environment variable 'name' if defined and not
  * empty, or NULL otherwise. Note that the returned pointer may become
  * invalid if linker_env_unset() or linker_env_secure() are called
  * after this function. */
-extern const char* linker_env_get(const char* name);
+extern const char* apkenv_linker_env_get(const char* name);
 
 /* Remove unsecure environment variables. This should be used when
  * running setuid programs. */
-extern void        linker_env_secure(void);
+extern void        apkenv_linker_env_secure(void);
 
 #endif /* LINKER_ENVIRON_H */

--- a/linker/rt.c
+++ b/linker/rt.c
@@ -30,7 +30,7 @@
  * This function is an empty stub where GDB locates a breakpoint to get notified
  * about linker activity.
  */
-void __attribute__((noinline)) rtld_db_dlactivity(void)
+void __attribute__((noinline)) apkenv_rtld_db_dlactivity(void)
 {
 }
 

--- a/linker/strlcpy.c
+++ b/linker/strlcpy.c
@@ -24,7 +24,7 @@
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
 size_t
-strlcpy(char *dst, const char *src, size_t siz)
+apkenv_strlcpy(char *dst, const char *src, size_t siz)
 {
 	char *d = dst;
 	const char *s = src;

--- a/linker/strlcpy.h
+++ b/linker/strlcpy.h
@@ -5,6 +5,6 @@
 #include <string.h>
 
 size_t
-strlcpy(char *dst, const char *src, size_t siz);
+apkenv_strlcpy(char *dst, const char *src, size_t siz);
 
 #endif


### PR DESCRIPTION
This solves a conflict between libhybris and apkenv on SailfishOS powered devices which utilize libhybris.

Problem:
apkenv and libhybris have many common function names because they
both use the android linker for the magic they achieve.
If one would start apkenv without this patch the glibc linker ld
will get confused and calls apkenvs version of the linker functions
where it should call the libhybris ones. This happens when apkenv
is not fully initialized (before main, while libhybris is linking
the android driver blobs) which is bad because the hooks in apkenv
will not be initialized at that time so no functions will be
hooked. This will result in the output of
"Unimplemented: pthread_*" and the termination of apkenv (because
pthread functions in apkenv must be hooked). Also it is probably
a bad idea that the libhybris functions get overwritten with apkenvs
functions.

Solution:
Prefix all functions in linker/*.{c,h} (and as an addition add
static where possible). This will avoid function name clashes and
enables apkenv to be run on SailfishOS.
