### PR TITLE
Implement automatic dependency generation in makefile. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.d
 *.o
 cscope.out
 tags


### PR DESCRIPTION
This implements automatic dependency generation in makefile.

Up until now, if one would for example change compat/pthread_mapping.h and then execute make, make would assume that nothing has changed and wouldn't recompile hooks.c one would either have to run "make clean" or delete hooks.o manually, this commit changes this.

Code is based upon http://scottmcpeak.com/autodepend/autodepend.html see "One More Tweak".
