### PR TITLE
fix thumb wrappers

### DIFF
--- a/debug/wrappers/wrapper_code_arm.c
+++ b/debug/wrappers/wrapper_code_arm.c
@@ -4,7 +4,6 @@ void
 wrapper_code_arm()
 {
     asm volatile(
-        // don't use any labels within the code because our *.o to code converter will stop at the first label
         // preserve the registers
         "push {r0-r11, lr}\n"
         

--- a/debug/wrappers/wrapper_code_thumb.c
+++ b/debug/wrappers/wrapper_code_thumb.c
@@ -5,13 +5,12 @@ wrapper_code_thumb()
 {
     // the thumb wrapper does not work yet
     asm volatile(
-        // don't use any labels within the code because our *.o to code converter will stop at the first label
         // preserve the registers
         "push {r0-r11, lr}\n"
         
         // now that everything is secure we can call a function
         "ldrd r0, fun\n" // load the function pointer to r0
-        "sub r0, r0, #2\n" // correct the pointer (TODO: check if this is correct)
+        "sub r0, r0, #8\n" // correct the pointer (TODO: this is slightly of for different cases, but it is only a printed value, not actually used)
         "ldrd r1, name\n" // load the address of the functions name to r1
         "ldrd r2, str\n" // load the string to print
         "ldrd r4, tc\n" // load the address of print_fun_name to r4
@@ -21,16 +20,22 @@ wrapper_code_thumb()
 
         // restore the registers
         "pop {r0-r11, lr}\n"
-        "mov pc, lr\n" // test
-        "mov r0, r0\n"
-
-        // reserved space for 2 up to 5 thumb instructions (16-bit vs 32-Bit)
+        // reserved space for thumb instructions
         "mov r0, r0\n"
         "mov r0, r0\n"
         "mov r0, r0\n"
         "mov r0, r0\n"
         "mov r0, r0\n"
-        "ldr pc, fun\n" // jump to the 3rd instruction of the wrapped function
+        "mov r0, r0\n"
+        "mov r0, r0\n"
+        "mov r0, r0\n"
+        "mov r0, r0\n"
+        // load the address to which we should jump
+        "push {r0}\n"
+        "ldr r0, fun\n"
+        "mov ip, r0\n"
+        "pop {r0}\n"
+        "bx ip\n" // jump to the first uncopied instruction of the wrapped function
 
         // the following is only needed because of the labels
         // we could rewrite this and omit the following but it's not
@@ -38,7 +43,7 @@ wrapper_code_thumb()
 
         // dummy instructions, this is where we locate our pointers
         "name: .word 0xFFFFFFFF\n" // name of function to call
-        "fun: .word 0xFFFFFFFF\n" // function to call (actually the pointer to the third instruction)
+        "fun: .word 0xFFFFFFFF\n" // function to call (actually the pointer to the first uncopied instruction)
         "tc: .word 0xFFFFFFFF\n" // address of print_fun_name
         "str: .word 0xFFFFFFFF\n" // the string being printed in trace_callback
     );


### PR DESCRIPTION
something i wanted to fix for a long time now, unfortunately i cannot test it as my n9 won't power on anymore and i cannot get apkenv to start on the jolla phone... i tried to think of everything before i commited it, i hope it will work right away... please test

the reason for this change is that "ldr pc, fun" does not work as it is supposed to (at least in thumb code, in arm code is works fine). i have changed this an made some cleanups

EDIT: to test this someone would have to find a suitable thumb function, which doesn't do something fancy with pc and stuff in the first 16 bytes (i am saying it in byte because there might be different number of instructions, depending how many of them are thumb 16 bit or thumb 32 bit instructions), and enable tracing for it (as well as specifying "-ti" of course) and then see if calls to that function are properly printed out on the terminal :)