### PR TITLE
Fixes

### DIFF
--- a/apkenv.h
+++ b/apkenv.h
@@ -59,6 +59,7 @@ struct ModuleHacks {
     int gles_no_readpixels;
     int gles_viewport_hack;
     int gles_scale;
+    int glOrthof_rotation_hack;
 };
 
 struct SupportModule {

--- a/compat/gles_wrappers.c
+++ b/compat/gles_wrappers.c
@@ -554,7 +554,20 @@ void
 my_glMultMatrixf(const GLfloat *m)
 {
     WRAPPERS_DEBUG_PRINTF("glMultMatrixf()\n", m);
-    functions.glMultMatrixf(m);
+    if(matrix_mode == GL_PROJECTION && global.platform->get_orientation() != global_module_hacks.current_orientation) {
+        WRAPPERS_DEBUG_PRINTF("glMultMatrixf rotation hack\n");
+        if(global_module_hacks.current_orientation == ORIENTATION_LANDSCAPE) {
+            functions.glRotatef(270, 0, 0, 1);
+            functions.glMultMatrixf(m);
+        }
+        else {
+            functions.glRotatef(90, 0, 0, 1);
+            functions.glMultMatrixf(m);
+        }
+    }
+    else {
+        functions.glMultMatrixf(m);
+    }
 }
 void
 my_glMultiTexCoord4f(GLenum target, GLfloat s, GLfloat t, GLfloat r, GLfloat q)

--- a/compat/gles_wrappers.c
+++ b/compat/gles_wrappers.c
@@ -522,6 +522,7 @@ my_glLoadMatrixf(const GLfloat *m)
 {
     WRAPPERS_DEBUG_PRINTF("glLoadMatrixf()\n", m);
     if(matrix_mode == GL_PROJECTION && global.platform->get_orientation() != global_module_hacks.current_orientation) {
+        WRAPPERS_DEBUG_PRINTF("glLoadMatrixf rotation hack\n");
         if(global_module_hacks.current_orientation == ORIENTATION_LANDSCAPE) {
             functions.glLoadIdentity();
             functions.glRotatef(270, 0, 0, 1);
@@ -571,12 +572,16 @@ void
 my_glOrthof(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top, GLfloat zNear, GLfloat zFar)
 {
     WRAPPERS_DEBUG_PRINTF("glOrthof()\n", left, right, bottom, top, zNear, zFar);
-    if(global.platform->get_orientation() != global_module_hacks.current_orientation) {
-        if(global_module_hacks.current_orientation == ORIENTATION_LANDSCAPE) {
-            functions.glRotatef(270, 0, 0, 1);
-        }
-        else {
-            functions.glRotatef(90, 0, 0, 1);
+    if(global_module_hacks.glOrthof_rotation_hack)
+    {
+        if(global.platform->get_orientation() != global_module_hacks.current_orientation) {
+            WRAPPERS_DEBUG_PRINTF("glOrthof rotation hack\n");
+            if(global_module_hacks.current_orientation == ORIENTATION_LANDSCAPE) {
+                functions.glRotatef(270, 0, 0, 1);
+            }
+            else {
+                functions.glRotatef(90, 0, 0, 1);
+            }
         }
     }
     functions.glOrthof(left, right, bottom, top, zNear, zFar);
@@ -1050,6 +1055,7 @@ my_glLoadMatrixx(const GLfixed *m)
 {
     WRAPPERS_DEBUG_PRINTF("glLoadMatrixx()\n", m);
     if(matrix_mode == GL_PROJECTION && global.platform->get_orientation() != global_module_hacks.current_orientation) {
+        WRAPPERS_DEBUG_PRINTF("glLoadMatrixx rotation hack\n");
         if(global_module_hacks.current_orientation == ORIENTATION_LANDSCAPE) {
             functions.glLoadIdentity();
             functions.glRotatex(270<<16, 0, 0, 1<<16);
@@ -1361,6 +1367,7 @@ my_glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
     WRAPPERS_DEBUG_PRINTF("glViewport(%d, %d, %d, %d)\n", x, y, width, height);
     if(global_module_hacks.gles_viewport_hack) {
+        WRAPPERS_DEBUG_PRINTF("glViewport rotation hack\n");
         if(global.platform->get_orientation() != global_module_hacks.current_orientation) {
             functions.glViewport(y, x, height, width);
         }

--- a/modules/marmalade.c
+++ b/modules/marmalade.c
@@ -872,6 +872,7 @@ marmalade_init(struct SupportModule *self, int width, int height, const char *ho
 {
     self->priv->global = GLOBAL_M;
     self->priv->global->module_hacks->current_orientation = ORIENTATION_LANDSCAPE;
+    self->priv->global->module_hacks->glOrthof_rotation_hack = 1;
     self->priv->module = self;
     self->priv->home = strdup(home);
 

--- a/modules/marmalade.c
+++ b/modules/marmalade.c
@@ -482,7 +482,12 @@ marmalade_CallIntMethodV(JNIEnv *env, jobject p1, jmethodID p2, va_list p3)
 
     if(method_is(getOrientation))
     {
-        return marmalade_priv.global->module_hacks->current_orientation;
+        if(marmalade_priv.global->module_hacks->current_orientation == ORIENTATION_PORTRAIT) {
+            return ANDROID_ORIENTATION_PORTRAIT;
+        }
+        else {
+            return ANDROID_ORIENTATION_LANDSCAPE;
+        }
     }
     else if(method_is(getNetworkType))
     {

--- a/modules/marmalade.c
+++ b/modules/marmalade.c
@@ -932,17 +932,17 @@ marmalade_input(struct SupportModule *self, int event, int x, int y, int finger)
        int action = 0;
        if(ACTION_DOWN == event)
        {
-           action = POINTER_DOWN;
+           action = TOUCH_DOWN;
            MODULE_DEBUG_PRINTF("onMotionEvent: down\n");
        }
        else if(ACTION_UP == event)
        {
-           action = POINTER_UP;
+           action = TOUCH_UP;
            MODULE_DEBUG_PRINTF("onMotionEvent: up\n");
        }
        else if(ACTION_MOVE == event)
        {
-           action = POINTER_MOVE;
+           action = TOUCH_MOVE;
            MODULE_DEBUG_PRINTF("onMotionEvent: move\n");
        }
 


### PR DESCRIPTION
fix some inter-game conflicts
add rotation hack for Sonic4 Episode I, note: commit message
The following games do now work on SailfishOS:
Fruit Ninja 1.5
Plants vs Zombies 1.3.16 (no sound)
Super Hexagon 1.0.3
World of Goo 1.0.6
Sonic 4 Episode I (no sound, some scaling issues)
Doodlejump (no sound, no input/accelerometer support)
Cut the Rope 1.3
That Rabbit Game 2
Petals Redux 1.0.2